### PR TITLE
Change for sdr dockerfile

### DIFF
--- a/sdr/Dockerfile
+++ b/sdr/Dockerfile
@@ -44,12 +44,9 @@ RUN apt-get update && apt-get install -y \
 
 # Clone the repository and build the project
 WORKDIR /tmp
-RUN git clone https://github.com/fair-acc/gnuradio4.git && \
+RUN git clone https://github.com/fair-acc/gnuradio4.git && \ 
     cd gnuradio4 && \
-    mkdir build && \
-    cd build 
-    #cd build && \
-    #cmake -G Ninja -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_BUILD_TYPE=Debug -DLLVM_USE_LINKER=lld .. && \
-    #ninja
-
+    cmake -S . -B build && \
+    cmake --build build -- -j$(nproc) 
+    
 CMD ["bash"]

--- a/sdr/Dockerfile
+++ b/sdr/Dockerfile
@@ -46,7 +46,9 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 RUN git clone https://github.com/fair-acc/gnuradio4.git && \ 
     cd gnuradio4 && \
-    cmake -S . -B build && \
-    cmake --build build -- -j$(nproc) 
+    mkdir build && \
+    cd build && \
+    cmake -G Ninja .. && \
+    ninja
     
 CMD ["bash"]

--- a/sdr/README.md
+++ b/sdr/README.md
@@ -1,4 +1,32 @@
 # sdr
 
-A set of tools for using software defined radio.
+A set of tools for using software defined radio.  
 
+1.Firstly, build an image with Dockerfile in dockerfiles/sdr/.  
+Navigate to the directory containing this Dockerfile and run:  
+`docker build -t image_name .`  
+Here `.` means using the current directory as the build context. Change the `image_name` to whatever you want like `gnuradio4`.  
+
+2.Create a container with this image  
+`xhost +local:docker`  
+`docker run -it --rm \`  
+`  -e DISPLAY=$DISPLAY \`  
+`  -e XDG_RUNTIME_DIR=/tmp/runtime-root \`   
+`  -e PULSE_SERVER=unix:/run/user/1000/pulse/native \`  
+`  -v /run/user/1000/pulse:/run/user/1000/pulse \`  
+`  -v /tmp/.X11-unix:/tmp/.X11-unix \`  
+`  --name container_name \`  
+`  --device=/dev/bus/usb \`  
+` image_name`  
+
+The first command allow Docker containers to access your X11 display for using GQRX. 
+`1000` is the user id checked by `id -u`. 
+In principle, LimeSDR should in /dev/bus/usb so this command allow docker container use it.  
+Also change the `image_name` and `container_name` to something good to memory.
+
+3.After container is created, it will be automaticlly started. Inside the container, run  
+`LimeUtil --find` to check if LimeSDR device is connected to the container.  
+Then navigate to the executable with  
+`cd gnuradio4/build/blocks/soapy/src`  
+Check with `ls`. The executable named "soapy_example" shoule be there.  
+One can also use `gqrx` to use GQRX in this container.

--- a/sdr/README.md
+++ b/sdr/README.md
@@ -9,7 +9,7 @@ Here `.` means using the current directory as the build context. Change the `ima
 
 2.Create a container with this image  
 `xhost +local:docker`  
-`docker run -it --rm \`  
+`docker run -it \`  
 `  -e DISPLAY=$DISPLAY \`  
 `  -e XDG_RUNTIME_DIR=/tmp/runtime-root \`   
 `  -e PULSE_SERVER=unix:/run/user/1000/pulse/native \`  


### PR DESCRIPTION
With this docker file, one can build an image contains compiled gnuradio4 for sdrcap. Create a container with this image will allow one to use soapy_example immediately.  