### PR TITLE
Add ninja install command to dockerfile

### DIFF
--- a/sdr/Dockerfile
+++ b/sdr/Dockerfile
@@ -49,6 +49,7 @@ RUN git clone https://github.com/fair-acc/gnuradio4.git && \
     mkdir build && \
     cd build && \
     cmake -G Ninja .. && \
-    ninja
+    ninja && \
+    ninja install
     
 CMD ["bash"]


### PR DESCRIPTION
I have tested this dockerfile. First I created a container from this image, then ran `ninja install` in /tmp/gnuradio4/build . After that I did git clone https://github.com/Ailu29/sdrTcap.git , which is my version of soapy2file. It can work well in the container, several .bin files created and can be read by helper scripts.
So please add `ninja install` in dockerfile then nothing need to be done with dockerfile. 
The soapy2file need further test. After I make sure it runs well I will pull request to your sdrTcap repository. Which will be the soapy_example can be compiled with this docker version GR4.